### PR TITLE
社員紹介一覧に、ページネーション機能作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
-
 gem 'paranoia'
+gem 'kaminari'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,18 @@ GEM
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     json (2.6.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -251,6 +263,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   paranoia
   pry-rails

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -3,7 +3,16 @@ class EmployeesController < ApplicationController
   before_action :set_form_option, only: %i(new create edit update)
 
   def index
-    @employees = Employee.active.order("#{sort_column} #{sort_direction}")
+    if sort_column == "number"
+      if sort_direction == 'asc'
+        @employees = Employee.active.sort
+      else
+        @employees = Employee.active.sort.reverse
+      end
+    else
+      @employees = Employee.active.order("#{sort_column} #{sort_direction}")
+    end
+    @employees = Kaminari.paginate_array(@employees).page(params[:page]).per(10)
   end
 
   def new

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -37,4 +37,5 @@
     <% end %>
     </tbody>
   </table>
+  <div><%= paginate @employees %></div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
+
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
   </head>
   <body>
     <% if logged_in? %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,3 +43,10 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
+  views:
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>
+      truncate: "..."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,8 +11,12 @@ OFFICE_NAME = %w[東京 仙台 大阪 福岡 大分]
 
 DEPARTMENT_NAME.each.with_index(1) { |department, i| Department.find_or_create_by(id: i, name: department) }
 OFFICE_NAME.each.with_index(1) { |office, i| Office.find_or_create_by(id: i, name: office) }
-Employee.find_or_create_by(id: 1, department_id: Department.find_by(name: '総務部').id,
-                           office_id: Office.find_by(name: '東京').id,
-                           number: '1', last_name: '山田', first_name: '太郎', account: 'yamada',
-                           password: 'hogehoge', email: 'yamada@example.co.jp', date_of_joining: '1991/4/1',
-                           employee_info_manage_auth: true)
+
+100.times do |i|
+  Employee.find_or_create_by(id: i+1, department_id: Department.find_by(name: '総務部').id,
+                            office_id: Office.find_by(name: '東京').id,
+                            number: (i+1).to_i, last_name: '山田' + (i+1).to_s, first_name: '太郎' + (i+1).to_s, account: 'yamada' + (i+1).to_s,
+                            password: 'hogehoge', email: 'yamada' + (i+1).to_s + '@example.co.jp', date_of_joining: '1991/4/1',
+                            employee_info_manage_auth: true, news_posts_auth: true)
+end
+


### PR DESCRIPTION

## 変更の概要
社員紹介一覧に、ページネーション機能作成

## なぜこの変更をするのか
* 変更をする理由
社員が多くなったときに見づらくなるため、１ページあたり10件でページネーション機能を実装。

## 変更内容
* UIの変更ならスクリーンショット
<img width="991" alt="image" src="https://user-images.githubusercontent.com/69975275/226649317-ef79ef2d-0dfc-48ed-908d-7fa7cd107044.png">

## 課題
* とくにレビューしてほしいところ
employees_controller.rbの記述を以下の通りにしています。
「社員番号」でソートしたとき、挙動としては合っていますが、
「number」カラムでソート出来ていないかもしれません。

  def index
    if sort_column == "number"
      if sort_direction == 'asc'
        @employees = Employee.active.sort
      else
        @employees = Employee.active.sort.reverse
      end
    else
      @employees = Employee.active.order("#{sort_column} #{sort_direction}")
    end
    @employees = Kaminari.paginate_array(@employees).page(params[:page]).per(10)
  end

## 備考
* その他に伝えたいこと
なし